### PR TITLE
feat: Implement unified LLM provider system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 # Hugging Face API token for generating ASCII art
 # Get your token from: https://huggingface.co/settings/tokens
 HUGGINGFACE_API_TOKEN=your_huggingface_token_here
-HUGGINGFACE_MODEL_ID=HuggingFaceTB/SmolLM-135M
-# Optional: Specify a different model to use (default: bigscience/bloom)
-# HUGGINGFACE_MODEL_ID=your_preferred_model
+
+# LLM Provider ("local" for HuggingFace, "ollama" for Ollama)
+TERMI_PROVIDER=local
+
+# Hugging Face Model Configuration
+HUGGINGFACE_MODEL_ID=distilgpt2
+HUGGINGFACE_MODEL_REVISION=main
+
+# Ollama Configuration (if TERMI_PROVIDER=ollama)
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_MODEL=llama2:7b

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # 🐮 Termipals
 
-Add some joy to your terminal with friendly ASCII art animals! Termipals uses a small local LLM to generate unique ASCII art animals on demand.
+Add some joy to your terminal with friendly ASCII art animals! Termipals uses a flexible LLM backend (defaulting to a small local model, with support for Ollama) to generate unique ASCII art animals on demand.
 
 ## 🚀 Features
 
-- Generate unique ASCII art animals using a local LLM
-- Save and reuse generated art
-- Display random animals
-- Inject animals into files
-- List available animals
-- Lightweight and fast
+- Generate unique ASCII art animals.
+- Flexible LLM backend: Uses a small local Hugging Face model by default, with automatic detection for Ollama, and manual configuration options.
+- Save and reuse generated art.
+- Display random animals.
+- Inject animals into files.
+- List available animals.
+- Lightweight and aims to be fast.
 
 ## 📦 Installation
 
@@ -29,8 +30,70 @@ source .venv/bin/activate  # On Windows, use: .venv\Scripts\activate
 ```bash
 pip install -e .
 ```
+    This will install Termipals and its dependencies, including `transformers`, `torch`, and `requests`.
 
-The first time you run a generation command, it will download the SmolLM model (about 250MB) to the `llm/models` directory.
+The first time you run a generation command with the default local Hugging Face provider, it will download the model (e.g., `distilgpt2`, approx. 300-400MB) to a cache directory (typically `~/.cache/termipals/models/`).
+
+## ⚙️ LLM Configuration
+
+Termipals intelligently selects an LLM provider. By default, it uses a built-in small Hugging Face model (`distilgpt2`). If you have Ollama running, it may be auto-detected and preferred. You can also explicitly configure the provider using environment variables.
+
+The selection priority is as follows:
+1.  **Explicit Provider**: Defined by the `TERMI_PROVIDER` environment variable.
+2.  **Auto-detection**: If `TERMI_PROVIDER` is not set, Termipals checks for a running Ollama instance.
+3.  **Default**: If no explicit provider is set and Ollama is not detected, Termipals defaults to using a local Hugging Face model.
+
+### Environment Variables
+
+You can control Termipals' LLM behavior using the following environment variables. You can set them in your shell or place them in a `.env` file in the project root.
+
+| Variable                     | Description                                                                                                | Default Value               |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `TERMI_PROVIDER`             | Specifies the LLM provider. Values: `local` (or `huggingface`) for local Hugging Face, `ollama` for Ollama.  | (empty, for auto-detect)  |
+| `HUGGINGFACE_MODEL_ID`       | The Hugging Face model ID to use when `TERMI_PROVIDER` is `local`.                                         | `distilgpt2`                |
+| `HUGGINGFACE_MODEL_REVISION` | The model revision (branch, tag, commit hash) for the Hugging Face model.                                  | `main`                      |
+| `OLLAMA_HOST`                | The host address for your Ollama server (e.g., `http://localhost:11434`).                                   | `http://localhost:11434`    |
+| `OLLAMA_MODEL`               | The model name to use with Ollama (must be pulled in Ollama first). Examples: `llama2:7b`, `orca-mini`.      | `llama2:7b`                 |
+| `OLLAMA_TEMPERATURE`         | Sets the temperature for Ollama generation (float, e.g., `0.7`).                                             | `0.7`                       |
+| `TERMI_CONNECTION_TIMEOUT`   | Timeout in seconds for establishing connections (e.g., to Ollama).                                         | `5`                         |
+| `TERMI_REQUEST_TIMEOUT`      | Timeout in seconds for the entire LLM request.                                                              | `60`                        |
+
+**Example `.env` file**:
+```env
+# Example .env file for Termipals
+
+# Uncomment and set the provider you want to use explicitly
+# TERMI_PROVIDER=ollama
+# TERMI_PROVIDER=local
+
+# Hugging Face specific settings (if using 'local' provider)
+# HUGGINGFACE_MODEL_ID=gpt2
+# HUGGINGFACE_MODEL_REVISION=main
+
+# Ollama specific settings (if using 'ollama' provider)
+# OLLAMA_HOST=http://127.0.0.1:11434
+# OLLAMA_MODEL=mistral:7b # Make sure you have pulled this model, e.g., ollama pull mistral:7b
+# OLLAMA_TEMPERATURE=0.6
+
+# Advanced: Timeouts (in seconds)
+# TERMI_CONNECTION_TIMEOUT=10
+# TERMI_REQUEST_TIMEOUT=180
+```
+*Note: Create a file named `.env` in the root of the project and add your configurations there. Termipals will automatically load it if `python-dotenv` is installed and `load_dotenv()` is called.*
+
+### Using Ollama
+
+To use Ollama with Termipals:
+1.  **Install Ollama**: Visit [ollama.com](https://ollama.com) and follow the installation instructions for your operating system.
+2.  **Ensure Ollama is running**: Typically, Ollama runs as a background service.
+3.  **Pull a model**: Before Termipals can use an Ollama model, you need to pull it. For example, to pull `orca-mini`:
+    ```bash
+    ollama pull orca-mini
+    ```
+    Other models like `llama2:7b`, `mistral:7b`, or `codellama:7b` can also be used.
+4.  **Configure Termipals**:
+    *   **Auto-detection**: If Ollama is running on the default host (`http://localhost:11434`), Termipals should detect it automatically if `TERMI_PROVIDER` is not set.
+    *   **Manual Configuration**: Set `TERMI_PROVIDER=ollama` in your environment or `.env` file. You can also specify `OLLAMA_HOST` and `OLLAMA_MODEL` if they differ from the defaults.
 
 ## 🎮 Usage
 
@@ -39,15 +102,16 @@ The first time you run a generation command, it will download the SmolLM model (
 # Show a random animal
 termipals
 
-# Show a specific animal
+# Show a specific animal (if previously generated and saved)
 termipals cat
 ```
 
 ### Generate new art
 ```bash
-# Generate ASCII art for a new animal
+# Generate ASCII art for a new animal (e.g., an elephant)
 termipals --create elephant
 ```
+*This will use the configured or auto-detected LLM provider.*
 
 ### List available animals
 ```bash
@@ -62,7 +126,7 @@ termipals cat myfile.txt
 
 ### Debug mode
 ```bash
-# Enable debug output
+# Enable debug output, useful for seeing provider selection and generation details
 termipals --debug --create unicorn
 ```
 
@@ -70,23 +134,31 @@ termipals --debug --create unicorn
 
 ```
 termipals/
-├── llm/
-│   └── models/          # LLM model storage
+├── .env.example         # Example environment file
+├── llm/                 # (No longer for models, cache is ~/.cache/termipals/models/)
 ├── termipals/
+│   ├── __init__.py
+│   ├── llm_provider.py  # LLM provider implementations (HuggingFace, Ollama)
 │   ├── assets/
-│   │   └── animals/    # Generated ASCII art
-│   └── cli/           # CLI implementation
-└── docs/              # Documentation
+│   │   └── animals/     # Saved generated ASCII art
+│   └── cli/
+│       ├── __init__.py
+│       └── main.py      # CLI implementation
+├── README.md
+├── setup.py
+└── ... (other project files)
 ```
+*Note: The primary Hugging Face model cache is now typically `~/.cache/termipals/models/`.*
 
 ## 🛠️ Development
 
-1. Clone the repository
-2. Create a virtual environment
-3. Install development dependencies:
-```bash
-pip install -e ".[dev]"
-```
+1.  Clone the repository.
+2.  Create a virtual environment (see Installation).
+3.  Install development dependencies:
+    ```bash
+    pip install -e ".[dev]"
+    ```
+    *(Ensure your `setup.py` includes a `[dev]` extra with tools like `pytest`, `flake8` etc.)*
 
 ## 📝 License
 
@@ -95,3 +167,4 @@ MIT License - feel free to use and modify!
 ## 🤝 Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
+If you encounter any issues or have feature suggestions, please open an issue on GitHub.

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ install_requires = [
     "accelerate",
     "tqdm",
     "python-dotenv",
+    "requests", # Added requests
 ]
 
 setup(

--- a/termipals/__init__.py
+++ b/termipals/__init__.py
@@ -1,0 +1,4 @@
+"""
+Termipals package.
+"""
+from .llm_provider import LLMProvider, HuggingFaceProvider, OllamaProvider

--- a/termipals/llm_provider.py
+++ b/termipals/llm_provider.py
@@ -1,0 +1,417 @@
+import abc
+import logging
+from pathlib import Path
+import re
+
+# Import Hugging Face specific libraries
+try:
+    import torch
+    from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+except ImportError:
+    # This will be handled by is_available() in HuggingFaceProvider
+    # and prevent its use if dependencies are missing.
+    pass
+
+# Configure basic logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+import importlib.util # Moved importlib.util to the top
+import requests # Added for OllamaProvider
+import json # Added for OllamaProvider
+
+
+class LLMProvider(abc.ABC):
+    """Abstract base class for LLM providers."""
+
+    def __init__(self, config: dict):
+        """
+        Initializes the LLM provider with configuration parameters.
+
+        Args:
+            config: A dictionary containing configuration parameters.
+        """
+        self.config = config
+
+    @abc.abstractmethod
+    def generate_art(self, prompt_messages: list) -> str:
+        """
+        Generates art based on the given prompt messages.
+
+        Args:
+            prompt_messages: A list of messages representing the prompt.
+
+        Returns:
+            A string representing the generated art.
+        """
+        pass
+
+    @abc.abstractmethod
+    def is_available(self) -> bool:
+        """
+        Checks if the LLM provider is available.
+
+        Returns:
+            True if the provider is available, False otherwise.
+        """
+        pass
+
+
+class HuggingFaceProvider(LLMProvider):
+    """LLM provider for Hugging Face models."""
+
+    def __init__(self, config: dict):
+        """
+        Initializes the HuggingFaceProvider.
+
+        Args:
+            config: A dictionary containing configuration parameters.
+                    Expected keys: "huggingface_model_id", "huggingface_model_revision".
+        """
+        super().__init__(config)
+        self.model_id = self.config.get("huggingface_model_id", "distilgpt2")
+        self.revision = self.config.get("huggingface_model_revision", "main")
+        self.pipe = None
+        # Sanitize model_id for directory creation
+        safe_model_id_path = self.model_id.replace("/", "_")
+        self.model_dir = Path.home() / '.cache' / 'termipals' / 'models' / safe_model_id_path
+        self.logger = logging.getLogger(__name__)
+        self.tokenizer = None
+        self.model = None
+
+    def setup_model(self):
+        """
+        Downloads (if necessary) and loads the Hugging Face model and tokenizer.
+        Initializes the generation pipeline.
+        """
+        if not self.model_dir.exists():
+            self.model_dir.mkdir(parents=True, exist_ok=True)
+            self.logger.info(f"Created model directory: {self.model_dir}")
+
+        try:
+            self.logger.info(f"Loading tokenizer for {self.model_id} (revision: {self.revision}) from {self.model_dir}...")
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                str(self.model_dir), local_files_only=True, trust_remote_code=True
+            )
+            self.logger.info("Tokenizer loaded successfully from local cache.")
+        except OSError:
+            self.logger.info(f"Tokenizer not found locally. Downloading and caching to {self.model_dir}...")
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                self.model_id, revision=self.revision, trust_remote_code=True
+            )
+            self.tokenizer.save_pretrained(str(self.model_dir))
+            self.logger.info("Tokenizer downloaded and cached.")
+
+        try:
+            self.logger.info(f"Loading model {self.model_id} (revision: {self.revision}) from {self.model_dir}...")
+            self.model = AutoModelForCausalLM.from_pretrained(
+                str(self.model_dir), local_files_only=True, trust_remote_code=True
+            )
+            self.logger.info("Model loaded successfully from local cache.")
+        except OSError:
+            self.logger.info(f"Model not found locally. Downloading and caching to {self.model_dir}...")
+            self.model = AutoModelForCausalLM.from_pretrained(
+                self.model_id, revision=self.revision, trust_remote_code=True
+            )
+            self.model.save_pretrained(str(self.model_dir))
+            self.logger.info("Model downloaded and cached.")
+
+        # Ensure model is on the correct device (e.g., GPU if available)
+        device = 0 if torch.cuda.is_available() else -1
+        if device == 0:
+            self.logger.info("CUDA is available. Using GPU.")
+            if self.model.device.type != "cuda": # Only move if not already on CUDA
+                 self.model.to("cuda")
+        else:
+            self.logger.info("CUDA not available. Using CPU.")
+
+
+        self.logger.info("Initializing text generation pipeline...")
+        self.pipe = pipeline(
+            "text-generation",
+            model=self.model,
+            tokenizer=self.tokenizer,
+            # device=device # device argument for pipeline
+        )
+        self.logger.info("Text generation pipeline initialized.")
+
+
+    def _clean_art(self, generated_text: str) -> str:
+        """Cleans the generated text to extract ASCII art."""
+        # Remove chatml markers if present
+        cleaned_text = generated_text.replace("<|assistant|>", "").replace("<|user|>", "").replace("<|system|>", "")
+
+        # Find the start of the ASCII art
+        start_marker = "```ascii"
+        start_index = cleaned_text.find(start_marker)
+        if start_index != -1:
+            cleaned_text = cleaned_text[start_index + len(start_marker):]
+            # Remove the marker itself and any preceding newlines
+            cleaned_text = cleaned_text.lstrip('\n')
+
+        # Find the end of the ASCII art
+        end_marker = "```"
+        end_index = cleaned_text.rfind(end_marker)
+        if end_index != -1:
+            cleaned_text = cleaned_text[:end_index]
+
+        # Also remove common model apologies or refusals if they appear before art
+        apology_patterns = [
+            r"I apologize, but I cannot fulfill this request.*?\n",
+            r"I'm sorry, I can't create ASCII art.*?\n",
+            r"I am unable to generate images or ASCII art.*?\n",
+            r"As a large language model, I don't have the ability to create images.*?\n"
+        ]
+        for pattern in apology_patterns:
+            cleaned_text = re.sub(pattern, "", cleaned_text, flags=re.IGNORECASE | re.DOTALL)
+
+        return cleaned_text.strip()
+
+    def generate_art(self, prompt_messages: list) -> str:
+        """
+        Generates art using the Hugging Face model.
+
+        Args:
+            prompt_messages: A list of messages representing the prompt.
+                           Example: [{"role": "user", "content": "Draw a cat."}]
+
+        Returns:
+            A string representing the generated art.
+        """
+        if self.pipe is None:
+            try:
+                self.setup_model()
+            except Exception as e:
+                self.logger.error(f"Error setting up Hugging Face model: {e}")
+                return f"Error: Could not load model {self.model_id}. Check logs."
+
+        if not self.pipe:
+             return "Error: Text generation pipeline not available."
+
+        generation_args = {
+            "max_new_tokens": 500,
+            "temperature": 0.7, # Adjusted for creativity
+            "top_k": 50,
+            "top_p": 0.95,
+            "do_sample": True, # Important for creative tasks
+            "pad_token_id": self.tokenizer.eos_token_id if self.tokenizer else 50256, # Use EOS token for padding
+            "eos_token_id": self.tokenizer.eos_token_id if self.tokenizer else 50256,
+        }
+
+        self.logger.info(f"Generating art with prompt: {prompt_messages}")
+
+        # The pipeline expects a list of conversations or a single string.
+        # If prompt_messages is a list of dicts, format it.
+        # For many models, a simple concatenation of "role: content" is not ideal.
+        # It's better to use the tokenizer's apply_chat_template if available,
+        # or format as a single string prompt.
+        # For now, assuming prompt_messages is a list of dicts like:
+        # [{"role": "user", "content": "prompt"}, {"role": "assistant", "content": "response (optional)"}]
+        # We will take the last user message as the primary prompt for basic text-generation.
+        # More complex chat handling would require apply_chat_template.
+
+        input_text = ""
+        if isinstance(prompt_messages, list) and prompt_messages:
+            # Attempt to use apply_chat_template if available and it's a newer feature
+            if hasattr(self.tokenizer, 'apply_chat_template') and callable(self.tokenizer.apply_chat_template):
+                try:
+                    input_text = self.tokenizer.apply_chat_template(
+                        prompt_messages,
+                        tokenize=False,
+                        add_generation_prompt=True
+                    )
+                    self.logger.info(f"Using chat template. Input text: {input_text}")
+                except Exception as e:
+                    self.logger.warning(f"Failed to apply chat template: {e}. Falling back to simpler prompt string.")
+                    # Fallback for models that don't support it well or if there's an error
+                    last_user_message = next((msg['content'] for msg in reversed(prompt_messages) if msg['role'] == 'user'), None)
+                    if last_user_message:
+                        input_text = last_user_message
+                    else: # if no user message, concatenate all
+                        input_text = " ".join([msg['content'] for msg in prompt_messages])
+
+            else: # Older tokenizer or simple case: concatenate content from user messages
+                last_user_message = next((msg['content'] for msg in reversed(prompt_messages) if msg['role'] == 'user'), None)
+                if last_user_message:
+                    input_text = last_user_message
+                else: # if no user message, concatenate all
+                    input_text = " ".join([msg['content'] for msg in prompt_messages])
+        elif isinstance(prompt_messages, str): # If it's already a string
+            input_text = prompt_messages
+        else:
+            self.logger.error("Invalid prompt_messages format. Expected list of dicts or string.")
+            return "Error: Invalid prompt format."
+
+        if not input_text:
+            self.logger.warning("Prompt is empty after processing.")
+            return "Error: Prompt is empty."
+
+        self.logger.info(f"Processed input text for pipeline: {input_text[:200]}...") # Log snippet
+
+        try:
+            outputs = self.pipe(input_text, **generation_args)
+            generated_text = outputs[0]['generated_text']
+
+            # The actual prompt might be included in the generated_text by some models
+            # We should try to remove it if apply_chat_template was not used or was not effective
+            if hasattr(self.tokenizer, 'apply_chat_template') and input_text in generated_text and not input_text.endswith(generated_text):
+                 # Check if input_text is a prefix of generated_text and not the whole string
+                if generated_text.startswith(input_text):
+                    generated_text = generated_text[len(input_text):]
+
+            self.logger.info(f"Raw generated text: {generated_text[:300]}...") # Log snippet
+            art = self._clean_art(generated_text)
+            return art
+        except Exception as e:
+            self.logger.error(f"Error during text generation: {e}")
+            import traceback
+            self.logger.error(traceback.format_exc())
+            return f"Error: Failed to generate art. {e}"
+
+
+    def is_available(self) -> bool:
+        """
+        Checks if the Hugging Face provider is available (e.g., dependencies installed).
+        """
+        try:
+            importlib.util.find_spec("torch")
+            importlib.util.find_spec("transformers")
+            return True
+        except ImportError:
+            self.logger.warning("HuggingFaceProvider: Missing torch or transformers library.")
+            return False
+
+
+class OllamaProvider(LLMProvider):
+    """LLM provider for Ollama models."""
+
+    def __init__(self, config: dict):
+        """
+        Initializes the OllamaProvider.
+
+        Args:
+            config: A dictionary containing configuration parameters.
+                    Expected keys: "ollama_host", "ollama_model_name".
+        """
+        super().__init__(config)
+        self.host = self.config.get("ollama_host", "http://localhost:11434").rstrip('/') # Ensure no trailing slash
+        self.model_name = self.config.get("ollama_model_name", "llama2:7b")
+        self.api_url = f"{self.host}/api/generate"
+        self.tags_url = f"{self.host}/api/tags"
+        self.logger = logging.getLogger(__name__)
+
+    def _build_ollama_prompt(self, prompt_messages: list) -> str:
+        """
+        Builds a single prompt string from a list of message dictionaries
+        for Ollama.
+        """
+        full_prompt_parts = []
+        system_prompt = ""
+        user_prompts = []
+
+        for message in prompt_messages:
+            role = message.get("role")
+            content = message.get("content")
+            if not content:
+                continue
+            if role == "system":
+                system_prompt = content # Ollama typically takes system prompt separately or at the start
+            elif role == "user":
+                user_prompts.append(content)
+            # Assistant messages could be used for few-shot prompting if needed
+            # else:
+            #    full_prompt_parts.append(f"{role}: {content}")
+
+        if system_prompt: # Prepend system prompt if it exists
+            full_prompt_parts.append(system_prompt)
+
+        full_prompt_parts.extend(user_prompts) # Add all user prompts
+
+        return "\n".join(full_prompt_parts)
+
+
+    def generate_art(self, prompt_messages: list) -> str:
+        """
+        Generates art using an Ollama model.
+
+        Args:
+            prompt_messages: A list of messages representing the prompt.
+
+        Returns:
+            A string representing the generated art or an error message.
+        """
+        if not self.is_available(): # Check availability before trying to generate
+            return "Error: Ollama provider is not available. Please check connection and configuration."
+
+        combined_prompt = self._build_ollama_prompt(prompt_messages)
+        if not combined_prompt:
+            return "Error: Prompt is empty after processing messages."
+
+        payload = {
+            "model": self.model_name,
+            "prompt": combined_prompt,
+            "stream": False, # Keep it simple for now
+            "options": self.config.get("ollama_options", {"temperature": 0.7}) # Get options from config or default
+        }
+
+        self.logger.info(f"Sending request to Ollama API: {self.api_url} with model {self.model_name}")
+        self.logger.debug(f"Ollama payload: {json.dumps(payload, indent=2)}")
+
+        try:
+            response = requests.post(self.api_url, json=payload, timeout=self.config.get("request_timeout", 60))
+            response.raise_for_status()  # Raise an exception for HTTP errors (4xx or 5xx)
+
+            response_data = response.json()
+            self.logger.debug(f"Ollama raw response: {response_data}")
+
+            generated_art = response_data.get("response")
+            if generated_art:
+                # As per subtask, direct response for now. Cleaning can be added later.
+                # art = self._clean_art(generated_art) # If a shared/simple cleaner is available
+                return generated_art.strip()
+            else:
+                error_message = response_data.get("error", "Unknown error from Ollama")
+                self.logger.error(f"Ollama API error: {error_message}")
+                # Check if the model is available if a "model not found" type error occurs
+                if "model not found" in error_message.lower() or (response_data.get("status_code") == 404 and "model" in error_message.lower()):
+                     self.logger.error(f"Model '{self.model_name}' might not be available on Ollama host '{self.host}'. Please pull it with 'ollama pull {self.model_name}'.")
+                     return f"Error: Model '{self.model_name}' not found on Ollama host. Pull the model."
+
+                return f"Error: Ollama API did not return a response. Details: {error_message}"
+
+        except requests.exceptions.Timeout:
+            self.logger.error(f"Ollama API request timed out to {self.api_url}.")
+            return "Error: Ollama request timed out."
+        except requests.exceptions.ConnectionError:
+            self.logger.error(f"Ollama API connection error to {self.api_url}. Is Ollama running?")
+            return "Error: Could not connect to Ollama server."
+        except requests.exceptions.HTTPError as e:
+            self.logger.error(f"Ollama API HTTP error: {e.response.status_code} - {e.response.text}")
+            return f"Error: Ollama API request failed with status {e.response.status_code}."
+        except json.JSONDecodeError:
+            self.logger.error(f"Failed to decode JSON response from Ollama: {response.text}")
+            return "Error: Invalid JSON response from Ollama."
+        except Exception as e:
+            self.logger.error(f"An unexpected error occurred while communicating with Ollama: {e}")
+            import traceback
+            self.logger.error(traceback.format_exc())
+            return f"Error: An unexpected error occurred with Ollama. {e}"
+
+
+    def is_available(self) -> bool:
+        """
+        Checks if the Ollama provider is available by trying to connect to its API.
+        It checks the /api/tags endpoint.
+        """
+        try:
+            response = requests.get(self.tags_url, timeout=self.config.get("connection_timeout", 5)) # 5s timeout
+            if response.status_code == 200:
+                self.logger.info(f"Ollama provider detected and available at {self.host}")
+                # Optionally, check if self.model_name is in response.json()['models']
+                # For now, just confirming the server is up.
+                return True
+            else:
+                self.logger.warning(f"Ollama provider at {self.host} responded with status {response.status_code}. Not available.")
+                return False
+        except requests.exceptions.RequestException as e:
+            self.logger.warning(f"Ollama provider not available at {self.host}. Connection error: {e}")
+            return False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the `tests` directory as a package.

--- a/tests/test_termipals.py
+++ b/tests/test_termipals.py
@@ -1,0 +1,212 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import requests # For requests.exceptions.ConnectionError
+
+# Add project root to sys.path to allow direct import of termipals
+import sys
+from pathlib import Path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from termipals.cli.main import Termipals
+from termipals.llm_provider import HuggingFaceProvider, OllamaProvider
+
+# Default config values used in Termipals.__init__ for testing
+DEFAULT_HF_MODEL_ID = 'distilgpt2'
+DEFAULT_HF_REVISION = 'main'
+DEFAULT_OLLAMA_HOST = 'http://localhost:11434'
+DEFAULT_OLLAMA_MODEL = 'llama2:7b'
+DEFAULT_CONNECTION_TIMEOUT = 5
+DEFAULT_REQUEST_TIMEOUT = 60
+DEFAULT_OLLAMA_TEMPERATURE = 0.7
+
+class TestProviderSelection(unittest.TestCase):
+
+    def create_provider_config(self, hf_model_id=DEFAULT_HF_MODEL_ID, hf_revision=DEFAULT_HF_REVISION,
+                               ollama_host=DEFAULT_OLLAMA_HOST, ollama_model=DEFAULT_OLLAMA_MODEL,
+                               conn_timeout=DEFAULT_CONNECTION_TIMEOUT, req_timeout=DEFAULT_REQUEST_TIMEOUT,
+                               ollama_temp=DEFAULT_OLLAMA_TEMPERATURE):
+        return {
+            "huggingface_model_id": hf_model_id,
+            "huggingface_model_revision": hf_revision,
+            "ollama_host": ollama_host,
+            "ollama_model_name": ollama_model,
+            "connection_timeout": conn_timeout,
+            "request_timeout": req_timeout,
+            "ollama_options": {"temperature": ollama_temp}
+        }
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch('termipals.llm_provider.OllamaProvider.is_available', return_value=False)
+    def test_default_to_huggingface(self, mock_ollama_available):
+        """Test that HuggingFaceProvider is default when no env vars and Ollama not available."""
+        termipals_app = Termipals()
+        self.assertIsInstance(termipals_app.llm_provider, HuggingFaceProvider)
+        self.assertEqual(termipals_app.llm_provider.model_id, DEFAULT_HF_MODEL_ID)
+        self.assertEqual(termipals_app.llm_provider.revision, DEFAULT_HF_REVISION)
+        mock_ollama_available.assert_called_once() # Ensure auto-detection was attempted
+
+    @patch.dict(os.environ, {"TERMI_PROVIDER": "local"}, clear=True)
+    @patch('termipals.llm_provider.OllamaProvider.is_available') # Mock to prevent actual calls
+    def test_explicit_huggingface_provider(self, mock_ollama_is_available):
+        """Test explicit selection of HuggingFaceProvider via TERMI_PROVIDER=local."""
+        termipals_app = Termipals()
+        self.assertIsInstance(termipals_app.llm_provider, HuggingFaceProvider)
+        self.assertEqual(termipals_app.llm_provider.model_id, DEFAULT_HF_MODEL_ID)
+        mock_ollama_is_available.assert_not_called() # No auto-detection if explicit
+
+    @patch.dict(os.environ, {"TERMI_PROVIDER": "huggingface", "HUGGINGFACE_MODEL_ID": "custom/model", "HUGGINGFACE_MODEL_REVISION": "custom_rev"}, clear=True)
+    @patch('termipals.llm_provider.OllamaProvider.is_available')
+    def test_explicit_huggingface_custom_model(self, mock_ollama_is_available):
+        """Test explicit HuggingFace with custom model ID and revision."""
+        termipals_app = Termipals()
+        self.assertIsInstance(termipals_app.llm_provider, HuggingFaceProvider)
+        self.assertEqual(termipals_app.llm_provider.model_id, "custom/model")
+        self.assertEqual(termipals_app.llm_provider.revision, "custom_rev")
+        mock_ollama_is_available.assert_not_called()
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch('termipals.llm_provider.OllamaProvider.is_available', return_value=True)
+    def test_autodetect_ollama(self, mock_ollama_available):
+        """Test auto-detection of OllamaProvider when it's available."""
+        termipals_app = Termipals()
+        self.assertIsInstance(termipals_app.llm_provider, OllamaProvider)
+        self.assertEqual(termipals_app.llm_provider.host, DEFAULT_OLLAMA_HOST)
+        self.assertEqual(termipals_app.llm_provider.model_name, DEFAULT_OLLAMA_MODEL)
+        mock_ollama_available.assert_called_once()
+
+    @patch.dict(os.environ, {"TERMI_PROVIDER": "ollama", "OLLAMA_HOST": "http://customhost:1234", "OLLAMA_MODEL": "custom_ollama_model"}, clear=True)
+    @patch('termipals.llm_provider.OllamaProvider.is_available', return_value=True)
+    def test_explicit_ollama_provider(self, mock_ollama_available):
+        """Test explicit selection of OllamaProvider with custom settings."""
+        termipals_app = Termipals()
+        self.assertIsInstance(termipals_app.llm_provider, OllamaProvider)
+        self.assertEqual(termipals_app.llm_provider.host, "http://customhost:1234")
+        self.assertEqual(termipals_app.llm_provider.model_name, "custom_ollama_model")
+        mock_ollama_available.assert_called_once() # is_available is checked even if explicit
+
+    @patch.dict(os.environ, {"TERMI_PROVIDER": "ollama"}, clear=True)
+    @patch('termipals.llm_provider.OllamaProvider.is_available', return_value=False)
+    @patch('termipals.llm_provider.HuggingFaceProvider.is_available', return_value=True) # Assuming HF is always available for fallback
+    def test_explicit_ollama_unavailable_fallback(self, mock_hf_available, mock_ollama_available):
+        """Test fallback to HuggingFace when explicit Ollama is unavailable."""
+        termipals_app = Termipals()
+        self.assertIsInstance(termipals_app.llm_provider, HuggingFaceProvider)
+        self.assertEqual(termipals_app.llm_provider.model_id, DEFAULT_HF_MODEL_ID)
+        mock_ollama_available.assert_called_once()
+
+    @patch.dict(os.environ, {"TERMI_PROVIDER": "unknown_provider"}, clear=True)
+    @patch('termipals.llm_provider.OllamaProvider.is_available', return_value=False) # Ensure Ollama auto-detect also fails
+    @patch('termipals.llm_provider.HuggingFaceProvider.is_available', return_value=True)
+    def test_unrecognized_provider_fallback(self, mock_hf_available, mock_ollama_available):
+        """Test fallback to HuggingFace for an unrecognized TERMI_PROVIDER."""
+        termipals_app = Termipals()
+        self.assertIsInstance(termipals_app.llm_provider, HuggingFaceProvider)
+        self.assertEqual(termipals_app.llm_provider.model_id, DEFAULT_HF_MODEL_ID)
+        # No OllamaProvider.is_available call if provider_name is unrecognized and not empty
+        # The logic is: if provider_name -> try that provider. If fails -> fallback.
+        # If not provider_name -> try auto-detect Ollama. If fails -> fallback.
+        # In this case, provider_name is "unknown_provider", so OllamaProvider.is_available shouldn't be called for auto-detection.
+        # However, the current implementation in Termipals.__init__ might call it if the unknown provider init fails and self.llm_provider is None.
+        # Let's verify the calls based on current Termipals.__init__ logic:
+        # 1. Tries "unknown_provider" - fails (no such class) -> self.llm_provider is None
+        # 2. Then, because provider_name is not empty, it SKIPS auto-detection block.
+        # 3. Goes to final fallback.
+        # So, mock_ollama_available should NOT be called.
+        mock_ollama_available.assert_not_called()
+
+
+class TestOllamaProvider(unittest.TestCase):
+
+    def setUp(self):
+        self.sample_config = {
+            "ollama_host": "http://mockhost:11434",
+            "ollama_model_name": "mockmodel:latest",
+            "connection_timeout": 1,
+            "request_timeout": 5,
+            "ollama_options": {"temperature": 0.5}
+        }
+        # Ensure that HuggingFaceProvider doesn't try to download models during these tests
+        # by mocking its is_available to True and setup_model to do nothing.
+        # This is relevant if OllamaProvider tests inadvertently cause HF fallback logging.
+        patcher = patch('termipals.llm_provider.HuggingFaceProvider.is_available', return_value=True)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        patcher_setup = patch('termipals.llm_provider.HuggingFaceProvider.setup_model', return_value=None)
+        self.addCleanup(patcher_setup.stop)
+        patcher_setup.start()
+
+
+    @patch('requests.get')
+    def test_ollama_is_available_success(self, mock_get):
+        """Test OllamaProvider.is_available success."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        provider = OllamaProvider(config=self.sample_config)
+        self.assertTrue(provider.is_available())
+        mock_get.assert_called_once_with(f"{self.sample_config['ollama_host']}/api/tags", timeout=self.sample_config['connection_timeout'])
+
+    @patch('requests.get', side_effect=requests.exceptions.ConnectionError("Test connection error"))
+    def test_ollama_is_available_connection_error(self, mock_get):
+        """Test OllamaProvider.is_available handles ConnectionError."""
+        provider = OllamaProvider(config=self.sample_config)
+        self.assertFalse(provider.is_available())
+        mock_get.assert_called_once_with(f"{self.sample_config['ollama_host']}/api/tags", timeout=self.sample_config['connection_timeout'])
+
+    @patch('requests.post')
+    @patch('termipals.llm_provider.OllamaProvider.is_available', return_value=True) # Assume available for generate_art tests
+    def test_ollama_generate_art_success(self, mock_is_available, mock_post):
+        """Test OllamaProvider.generate_art success."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"response": "  mocked art  "} # With spaces for strip test
+        mock_post.return_value = mock_response
+
+        provider = OllamaProvider(config=self.sample_config)
+        prompt_messages = [{"role": "user", "content": "draw a cat"}]
+        art = provider.generate_art(prompt_messages)
+
+        self.assertEqual(art, "mocked art")
+        expected_payload = {
+            "model": self.sample_config['ollama_model_name'],
+            "prompt": "draw a cat", # From _build_ollama_prompt
+            "stream": False,
+            "options": self.sample_config['ollama_options']
+        }
+        mock_post.assert_called_once_with(
+            f"{self.sample_config['ollama_host']}/api/generate",
+            json=expected_payload,
+            timeout=self.sample_config['request_timeout']
+        )
+
+    @patch('requests.post', side_effect=requests.exceptions.Timeout("Test timeout"))
+    @patch('termipals.llm_provider.OllamaProvider.is_available', return_value=True)
+    def test_ollama_generate_art_timeout(self, mock_is_available, mock_post):
+        """Test OllamaProvider.generate_art handles Timeout."""
+        provider = OllamaProvider(config=self.sample_config)
+        prompt_messages = [{"role": "user", "content": "draw a dog"}]
+        art = provider.generate_art(prompt_messages)
+        self.assertTrue(art.startswith("Error: Ollama request timed out."))
+
+    @patch('requests.post')
+    @patch('termipals.llm_provider.OllamaProvider.is_available', return_value=True)
+    def test_ollama_generate_art_api_error(self, mock_is_available, mock_post):
+        """Test OllamaProvider.generate_art handles API error response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404 # Not Found
+        mock_response.json.return_value = {"error": "model 'testmodel' not found"}
+        mock_response.raise_for_status = MagicMock(side_effect=requests.exceptions.HTTPError(response=mock_response))
+        mock_post.return_value = mock_response
+
+        provider = OllamaProvider(config=self.sample_config)
+        prompt_messages = [{"role": "user", "content": "draw something"}]
+        art = provider.generate_art(prompt_messages)
+        self.assertTrue(art.startswith("Error: Ollama API request failed with status 404"))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a flexible LLM provider system to Termipals, allowing you to leverage local Hugging Face models or an Ollama service for ASCII art generation.

Key features and changes:

1.  **Unified Provider Abstraction (`llm_provider.py`)**:
    *   Introduces `LLMProvider` base class with `HuggingFaceProvider`
        and `OllamaProvider` concrete implementations.
    *   Providers handle their own configuration, model setup (if any),
        and art generation logic.

2.  **Provider Selection Logic (`cli/main.py`)**:
    *   Termipals now automatically selects an LLM provider based on
        the following priority:
        1.  Explicit configuration via `TERMI_PROVIDER` env var
            (`local`/`huggingface` or `ollama`).
        2.  Auto-detection of a running Ollama instance.
        3.  Default to a local Hugging Face model (`distilgpt2`).
    *   Fallbacks are in place if a selected provider is unavailable.

3.  **Enhanced Local Hugging Face Provider**:
    *   Defaults to `distilgpt2` for a smaller footprint.
    *   Model ID and revision are configurable via `HUGGINGFACE_MODEL_ID`
        and `HUGGINGFACE_MODEL_REVISION` env vars.
    *   Models are cached in `~/.cache/termipals/models/`.

4.  **Ollama Provider Integration**:
    *   Connects to an Ollama server (configurable via `OLLAMA_HOST`,
        defaults to `http://localhost:11434`).
    *   Uses the model specified by `OLLAMA_MODEL` (defaults to `llama2:7b`).
    *   Includes availability check and robust error handling for API calls.
    *   Requires `requests` library (added to dependencies).

5.  **Configuration via Environment Variables**:
    *   New `.env.example` file and updated README document all relevant
        environment variables for configuring providers, models, timeouts,
        and other settings (e.g., `TERMI_PROVIDER`, `HUGGINGFACE_MODEL_ID`,
        `OLLAMA_HOST`, `OLLAMA_MODEL`, `OLLAMA_TEMPERATURE`,
        `TERMI_CONNECTION_TIMEOUT`, `TERMI_REQUEST_TIMEOUT`).

6.  **Updated Documentation (`README.md`)**:
    *   Comprehensive updates explain the new provider system,
        configuration options, Ollama setup, and environment variables.

7.  **Unit Tests (`tests/test_termipals.py`)**:
    *   Added tests for the provider selection logic, ensuring correct
        behavior under various configurations and fallbacks.
    *   Includes unit tests for `OllamaProvider`'s availability check
        and art generation, using mocks for external calls.

This overhaul significantly enhances Termipals' flexibility and your experience by offering multiple LLM backends while maintaining a simple interface for basic use.